### PR TITLE
feat: 회원가입 처리

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,26 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
+import { JoinForm } from '../components/auth/Join/useJoin';
 import { AUTH_URL } from '../lib/constants';
+interface Flag {
+  code: string;
+  data: {
+    duplicateFlag: boolean;
+  };
+}
+
+interface sendEmailResponse {
+  data: {
+    certificationCode: string;
+    expirationDateTime: string;
+  };
+}
+
+interface checkCodeResponse {
+  data: {
+    token: string;
+    expirationDateTime: string;
+  };
+}
 
 const auth = axios.create({
   baseURL: AUTH_URL,
@@ -17,46 +38,59 @@ export const loginAPI = async (id: string, password: string) => {
 };
 
 export const checkIdAPI = async (id: string) => {
-  const response = await auth.post('/overlap/userid', {
+  const response: AxiosResponse<Flag> = await auth.post('/overlap/userid', {
     userid: id,
   });
-  return response;
+  return response.data;
 };
 
 export const checkEmailAPI = async (email: string) => {
-  const response = await auth.post('overlap/email', {
+  const response: AxiosResponse<Flag> = await auth.post('overlap/email', {
     email,
   });
-  return response;
+  return response.data;
 };
 
 export const checkNicknameAPI = async (nickname: string) => {
-  const response = await auth.post('/overlap/username', {
+  const response: AxiosResponse<Flag> = await auth.post('/overlap/username', {
     username: nickname,
   });
-  return response;
+  return response.data;
 };
 
 export const sendEmailAPI = async (email: string, token: string) => {
-  const response = await auth.post('/verification/email', {
-    email,
-    token,
-  });
-  return response;
+  const response: AxiosResponse<sendEmailResponse> = await auth.post(
+    '/verification/email',
+    {
+      email,
+      token,
+    },
+  );
+  return response.data.data;
 };
 
 export const checkCodeAPI = async (code: string, token: string) => {
-  const response = await auth.post('/verification/code', {
-    certificationCode: code,
-    token,
-  });
-  return response;
+  const response: AxiosResponse<checkCodeResponse> = await auth.post(
+    '/verification/code',
+    {
+      certificationCode: code,
+      token,
+    },
+  );
+  return response.data.data;
 };
 
-export const signUpAPI = async (id: string, password: string) => {
-  const response = await auth.post('/singUp', {
-    userid: id,
-    password,
+export const joinAPI = async (form: JoinForm) => {
+  const response = await auth.post('/join', {
+    email: form.email,
+    userid: form.id,
+    username: form.nickname,
+    password: form.password,
+    phoneNumber: form.phone,
+    postcode: '1234',
+    address: form.address,
+    detailAddress: form.detailAddress,
+    token: sessionStorage.getItem('signupToken'),
   });
   return response;
 };

--- a/src/components/Postcode/Postcode.tsx
+++ b/src/components/Postcode/Postcode.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import DaumPostcode, { Address } from 'react-daum-postcode';
+import useToggle from '../../hooks/useToggle';
+import { CheckBtn } from '../auth/Join/Join';
+import ModalTemplate from '../common/ModalTemplate';
+
+type PostcodeProps = {
+  handleComplete: any;
+};
+
+function Postcode({ handleComplete }: PostcodeProps) {
+  const [isPopUp, handlePopUp] = useToggle();
+
+  return (
+    <>
+      <CheckBtn onClick={handlePopUp}>주소검색</CheckBtn>
+      {isPopUp && (
+        <ModalTemplate
+          width="400px"
+          height="400px"
+          isModal={isPopUp}
+          onToggleModal={() => handlePopUp()}
+        >
+          <DaumPostcode
+            style={{
+              position: 'absolute',
+              right: 0,
+              width: '400px',
+            }}
+            onClose={handlePopUp}
+            onComplete={handleComplete}
+          />
+        </ModalTemplate>
+      )}
+    </>
+  );
+}
+
+export default Postcode;

--- a/src/components/auth/Join.tsx
+++ b/src/components/auth/Join.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function Join() {
-  return <div>임시</div>;
-}
-
-export default Join;

--- a/src/components/auth/Join/Join.tsx
+++ b/src/components/auth/Join/Join.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import styled from 'styled-components';
+import {
+  EMAIL_INVALID_CODE,
+  EMAIL_VALID_CODE,
+  ID_INVALID_CODE,
+  ID_VALID_CODE,
+  NICKNAME_INVALID_CODE,
+} from '../../../lib/constants';
+import palette from '../../../styles/palette';
+import Button from '../../common/Button';
+import Postcode from '../../Postcode/Postcode';
+import useJoin from './useJoin';
+
+function Join() {
+  const {
+    form,
+    responseCodes,
+    onChange,
+    onSubmit,
+    checkEmail,
+    checkCode,
+    checkId,
+    checkNickname,
+    handleComplete,
+  } = useJoin();
+
+  const { address, certificationCode } = form;
+  return (
+    <JoinBlock>
+      <h2 className="title">회원가입</h2>
+      <form onSubmit={onSubmit}>
+        <Row>
+          <label htmlFor="email">이메일</label>
+          <div className="check-field">
+            <input
+              id="email"
+              placeholder="이메일을 입력해주세요"
+              onChange={onChange}
+            />
+            <CheckBtn onClick={checkEmail} inverted>
+              중복확인
+            </CheckBtn>
+          </div>
+        </Row>
+        {responseCodes.email === EMAIL_INVALID_CODE && (
+          <ErrorMessage>이미 사용중인 이메일입니다.</ErrorMessage>
+        )}
+        {responseCodes.email === EMAIL_VALID_CODE && (
+          <Row>
+            <label htmlFor="email">인증번호</label>
+            <div className="check-field">
+              <input
+                placeholder="인증번호"
+                id="certificationCode"
+                value={certificationCode}
+                onChange={onChange}
+              />
+              <CheckBtn onClick={checkCode}>인증하기</CheckBtn>
+            </div>
+          </Row>
+        )}
+        <Row>
+          <label htmlFor="id">아이디</label>
+          <div className="check-field">
+            <input
+              id="id"
+              placeholder="아이디를 입력해주세요"
+              onChange={onChange}
+            />
+            <CheckBtn onClick={checkId} inverted>
+              중복확인
+            </CheckBtn>
+          </div>
+        </Row>
+        {responseCodes.id === ID_INVALID_CODE && (
+          <ErrorMessage>이미 사용중인 아이디입니다.</ErrorMessage>
+        )}
+        <Row>
+          <label htmlFor="nickname">닉네임</label>
+          <div className="check-field">
+            <input
+              id="nickname"
+              placeholder="닉네임을 입력해주세요"
+              onChange={onChange}
+            />
+            <CheckBtn onClick={checkNickname} inverted>
+              중복확인
+            </CheckBtn>
+          </div>
+        </Row>
+        {responseCodes.nickname === NICKNAME_INVALID_CODE && (
+          <ErrorMessage>이미 사용중인 닉네임입니다.</ErrorMessage>
+        )}
+        <Row>
+          <label htmlFor="password">비밀번호</label>
+          <input
+            type="password"
+            id="password"
+            placeholder="비밀번호를 입력해주세요"
+            onChange={onChange}
+          />
+        </Row>
+        <Row>
+          <label htmlFor="passwordCheck">비밀번호 확인</label>
+          <input
+            type="password"
+            id="passwordCheck"
+            placeholder="비밀번호 확인"
+            onChange={onChange}
+          />
+        </Row>
+        <Row>
+          <label htmlFor="phone">전화번호</label>
+          <input id="phone" placeholder="전화번호" onChange={onChange} />
+        </Row>
+        <Row>
+          <label htmlFor="address">우편번호</label>
+          <div className="check-field">
+            <input
+              id="address"
+              placeholder="우편번호"
+              readOnly={true}
+              value={address}
+            />
+            <Postcode handleComplete={handleComplete} />
+          </div>
+        </Row>
+        <Row>
+          <label htmlFor="detailAddress">상세주소</label>
+          <input id="detailAddress" placeholder="주소" onChange={onChange} />
+        </Row>
+        <CheckBtn>등록</CheckBtn>
+      </form>
+    </JoinBlock>
+  );
+}
+
+export default Join;
+
+const JoinBlock = styled.div`
+  width: 50rem;
+  margin: auto;
+  padding: 4.5rem 5.4375rem;
+  text-align: center;
+
+  .title {
+    text-align: center;
+  }
+`;
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.25rem;
+
+  .check-field {
+    display: flex;
+    width: 100%;
+  }
+
+  label {
+    width: 10rem;
+  }
+  input {
+    width: 100%;
+    height: 3.375rem;
+    padding: 0px 19px;
+    background-color: #f6f8fa;
+    border: none;
+    outline: none;
+    ::placeholder {
+      color: #8492a6;
+    }
+  }
+`;
+
+export const CheckBtn = styled(Button)`
+  width: 11rem;
+  margin-left: 1.1rem;
+`;
+
+const ErrorMessage = styled.p`
+  color: ${palette.red};
+`;

--- a/src/components/auth/Join/index.tsx
+++ b/src/components/auth/Join/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Join';

--- a/src/components/auth/Join/useJoin.ts
+++ b/src/components/auth/Join/useJoin.ts
@@ -1,0 +1,180 @@
+import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router';
+import {
+  checkCodeAPI,
+  checkEmailAPI,
+  checkIdAPI,
+  checkNicknameAPI,
+  joinAPI,
+  sendEmailAPI,
+} from '../../../api/auth';
+import { EMAIL_AUTH_SUCCESS_CODE } from '../../../lib/constants';
+
+type responseCodesType = {
+  email: null | string;
+  id: null | string;
+  nickname: null | string;
+};
+
+export type JoinForm = {
+  email: string;
+  id: string;
+  nickname: string;
+  password: string;
+  passwordConfirm: string;
+  phone: string;
+  address: string;
+  detailAddress: string;
+  emailToken: string;
+};
+
+function useJoin() {
+  const [form, setForm] = useState({
+    email: '',
+    id: '',
+    nickname: '',
+    password: '',
+    passwordConfirm: '',
+    phone: '',
+    address: '',
+    detailAddress: '',
+    emailToken: randomString(),
+    certificationCode: '',
+  });
+  const [isSuccess, setIsSuccess] = useState(false);
+  const history = useHistory();
+
+  const { email, id, nickname, emailToken, certificationCode } = form;
+
+  const [responseCodes, setResponseCodes] = useState<responseCodesType>({
+    email: null,
+    id: null,
+    nickname: null,
+  });
+
+  useEffect(() => {
+    if (isSuccess) {
+      history.push('/login');
+    }
+  }, [isSuccess]);
+
+  useEffect(() => {
+    if (responseCodes.email === EMAIL_AUTH_SUCCESS_CODE) {
+      sendEmail();
+    }
+  }, [responseCodes.email]);
+
+  const sendEmail = async () => {
+    try {
+      const { certificationCode } = await sendEmailAPI(email, emailToken);
+      sessionStorage.setItem('emailToken', certificationCode);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+  const checkId: React.MouseEventHandler<HTMLButtonElement> = async (e) => {
+    e.preventDefault();
+    try {
+      const { code } = await checkIdAPI(id);
+      setResponseCodes({ ...responseCodes, id: code });
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const checkNickname: React.MouseEventHandler<HTMLButtonElement> = async (
+    e,
+  ) => {
+    e.preventDefault();
+    try {
+      const { code } = await checkNicknameAPI(nickname);
+      setResponseCodes({ ...responseCodes, nickname: code });
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const checkEmail: React.MouseEventHandler<HTMLButtonElement> = async (e) => {
+    e.preventDefault();
+    try {
+      const { code } = await checkEmailAPI(email);
+      setResponseCodes({ ...responseCodes, email: code });
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const checkCode: React.MouseEventHandler<HTMLButtonElement> = async (e) => {
+    e.preventDefault();
+    try {
+      const { token } = await checkCodeAPI(certificationCode, emailToken);
+      sessionStorage.setItem('signupToken', token);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  const handleComplete = (data: any) => {
+    let fullAddress = data.address;
+    let extraAddress = '';
+
+    if (data.addressType === 'R') {
+      if (data.bname !== '') {
+        extraAddress += data.bname;
+      }
+      if (data.buildingName !== '') {
+        extraAddress +=
+          extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
+      }
+      fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
+    }
+    console.log(fullAddress); // e.g. '서울 성동구 왕십리로2길 20 (성수동1가)'
+    setForm({ ...form, address: fullAddress });
+  };
+
+  const onChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    const { id, value } = e.target;
+    setForm((state) => ({ ...state, [id]: value }));
+  };
+
+  const onSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+
+    try {
+      const response = await joinAPI(form);
+      if (response.status === 200) {
+        setIsSuccess(true);
+        alert('회원가입이 완료되었습니다');
+      }
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  return {
+    form,
+    responseCodes,
+    onChange,
+    onSubmit,
+    checkEmail,
+    sendEmail,
+    checkCode,
+    checkId,
+    checkNickname,
+    handleComplete,
+  };
+}
+
+export default useJoin;
+
+function randomString() {
+  const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
+  const stringLength = 16;
+  let randomstring = '';
+
+  for (let i = 0; i < stringLength; i++) {
+    const rnum = Math.floor(Math.random() * chars.length);
+    randomstring += chars.substring(rnum, rnum + 1);
+  }
+  return randomstring;
+}

--- a/src/components/common/ModalTemplate.tsx
+++ b/src/components/common/ModalTemplate.tsx
@@ -1,0 +1,71 @@
+import React, { ReactElement } from 'react';
+import styled from 'styled-components';
+
+interface InnerProps {
+  width: string;
+  height: string;
+  isModal: boolean;
+}
+
+interface ModalTemplateProps extends InnerProps {
+  onToggleModal: () => void;
+  children: React.ReactNode;
+}
+
+const ModalTemplateWrapper = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 9999;
+`;
+
+const Inner = styled.div<InnerProps>`
+  position: absolute;
+  z-index: 9999;
+  background-color: #ffffff;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  margin: auto;
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+  border-radius: 12px;
+`;
+
+const Background = styled.div`
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: #000;
+  position: absolute;
+  left: 0;
+  top: 0;
+  opacity: 0.4;
+`;
+
+function ModalTemplate({
+  width,
+  height,
+  isModal,
+  onToggleModal,
+  children,
+}: ModalTemplateProps): ReactElement {
+  return (
+    <ModalTemplateWrapper onMouseDown={onToggleModal}>
+      <Inner
+        onMouseDown={(e) => e.stopPropagation()}
+        width={width}
+        height={height}
+        isModal={isModal}
+      >
+        {children}
+      </Inner>
+      <Background />
+    </ModalTemplateWrapper>
+  );
+}
+
+export default ModalTemplate;

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+type ReturnTypes = [boolean, () => void];
+
+export default function useToggle(initialState = false): ReturnTypes {
+  const [isOpen, setIsOpen] = useState(initialState);
+
+  const onToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return [isOpen, onToggle];
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,2 +1,14 @@
 export const PRODUCT_URL = 'https://graduprojects.herokuapp.com';
 export const AUTH_URL = 'https://gradu-test.herokuapp.com';
+
+export const EMAIL_VALID_CODE = 'M101';
+export const EMAIL_INVALID_CODE = 'M107';
+
+export const EMAIL_AUTH_SUCCESS_CODE = 'M112';
+export const EMAIL_AUTH_FAILURE_CODE = 'C001';
+
+export const ID_VALID_CODE = 'M102';
+export const ID_INVALID_CODE = 'M108';
+
+export const NICKNAME_VALID_CODE = 'M103';
+export const NICKNAME_INVALID_CODE = 'M109';


### PR DESCRIPTION
- 회원가입 처리 
- ModalTemplate 공통 컴포넌트 추가, 사용 예시 컴포넌트 -> Postcode 컴포넌트 참고
- Modal등에서 사용하는 useToggle hook 추가

일단 로그인 처리를 다시 완벽하게 해야 다른 분들이 토큰 이용해서 API 콜을 할 수 있을꺼 같아서 
회원가입은 일단 이정도로 납두고 오늘 로그인 처리 부분 다시 작업하겠습니다! 
(평일에 너무 바빴네요ㅠㅠ 죄송합니다)

디렉토리 구조는 한번 새롭게 해봤어요~ 당장 적용해봐도 괜찮을꺼 같은것만 적용해봤습니다!
다음에 회의할때 같이 얘기해봐요
https://www.notion.so/35b8c5ccd92c4d33bd8edf01b4ce7c51


/* TODO */
1. 각 필드 유효성 검사 확인 후
- 사용 가능시 따로 사용자에게 피드백을 주고 있지 않음 -> 사용 가능하다는 메시지 표시하기,
- 중복, 사용 불가시 어떤 식으로 입력해야할지 피드백 줘야함

2. 중복되는 부분 모듈화

- 서버에서 처리한 유효성 검사 참고
0: {field: "phoneNumber", value: "", reason: "휴대폰 번호는 010-1234-5678 형태로 입력해주세요."}
1: {field: "password", value: "asdf", reason: "비밀번호는 숫자, 문자, 특수문자를 포함한 8자리 이상, 15자리 이하로 입력해주세요."}
2: {field: "username", value: "", reason: "닉네임은 2자리 이상, 10자리 이하로 입력해주세요."}
field: "username"
reason: "닉네임은 2자리 이상, 10자리 이하로 입력해주세요."
value: ""
3: {field: "email", value: "", reason: "이메일을 입력해주세요."}
4: {field: "phoneNumber", value: "", reason: "휴대폰 번호를 입력해주세요."}
5: {field: "userid", value: "", reason: "아이디를 입력해주세요."}
6: {field: "userid", value: "", reason: "아이디는 5~20자의 영소문자, 숫자만 사용 가능합니다."}
7: {field: "token", value: "", reason: "인증 토큰은 필수입니다."}
8: {field: "address", value: "", reason: "주소를 입력해주세요."}
9: {field: "detailAddress", value: "", reason: "상세주소를 입력해주세요."}
10: {field: "username", value: "", reason: "닉네임을 입력해주세요."}